### PR TITLE
Extracted local classes to global classes

### DIFF
--- a/src/zcl_cute_listbox_helper.clas.abap
+++ b/src/zcl_cute_listbox_helper.clas.abap
@@ -1,0 +1,42 @@
+CLASS zcl_cute_listbox_helper DEFINITION PUBLIC FINAL CREATE PUBLIC.
+  PUBLIC SECTION.
+    CLASS-METHODS get_listbox_for_fix_values
+      IMPORTING
+        domname              TYPE domname
+        handle               TYPE i
+        type                 TYPE zcute_field_display_type
+      RETURNING
+        VALUE(listbox_alias) TYPE lvc_t_dral.
+ENDCLASS.
+
+
+
+CLASS ZCL_CUTE_LISTBOX_HELPER IMPLEMENTATION.
+
+
+  METHOD get_listbox_for_fix_values.
+    DATA fix_values     TYPE STANDARD TABLE OF dd07v.
+
+    CALL FUNCTION 'DD_DOMVALUES_GET'
+      EXPORTING
+        domname        = domname
+        text           = 'X'
+        langu          = sy-langu
+      TABLES
+        dd07v_tab      = fix_values
+      EXCEPTIONS
+        wrong_textflag = 1
+        OTHERS         = 2.
+    IF sy-subrc = 0.
+      CASE type.
+        WHEN 'LK'.
+          listbox_alias = VALUE #( FOR value IN fix_values ( handle = handle int_value = value-domvalue_l value = value-domvalue_l ) ).
+        WHEN 'LT'.
+          listbox_alias = VALUE #( FOR value IN fix_values ( handle = handle int_value = value-domvalue_l value = value-ddtext ) ).
+        WHEN 'LB'.
+          listbox_alias = VALUE #( FOR value IN fix_values ( handle = handle int_value = value-domvalue_l value = |{ value-domvalue_l } { value-ddtext }| ) ).
+      ENDCASE.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_cute_listbox_helper.clas.xml
+++ b/src/zcl_cute_listbox_helper.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_CUTE_LISTBOX_HELPER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CUTE - Listbox Helper</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_cute_source_info_tabl.clas.abap
+++ b/src/zcl_cute_source_info_tabl.clas.abap
@@ -1,0 +1,95 @@
+class ZCL_CUTE_SOURCE_INFO_TABL definition
+  public
+  final
+  create public .
+
+public section.
+
+  interfaces ZIF_CUTE_SOURCE_INFO .
+
+  data HEADER type DD02V .
+  data TECHNICAL type DD09V .
+  data:
+    components TYPE STANDARD TABLE OF dd03p .
+ENDCLASS.
+
+
+
+CLASS ZCL_CUTE_SOURCE_INFO_TABL IMPLEMENTATION.
+
+
+  METHOD zif_cute_source_info~get_field_info.
+
+    DATA dfies_table TYPE STANDARD TABLE OF dfies.
+
+    READ TABLE zif_cute_source_info~fieldinfos WITH TABLE KEY fieldname = fieldname INTO fieldinfo.
+    IF sy-subrc > 0.
+      fieldinfo-fieldname = fieldname.
+
+      CALL FUNCTION 'DDIF_FIELDINFO_GET'
+        EXPORTING
+          tabname        = zif_cute_source_info~name
+          fieldname      = CONV fieldname( fieldname )
+          langu          = sy-langu
+          all_types      = 'X'
+          group_names    = ' '
+          do_not_write   = 'X'
+        TABLES
+          dfies_tab      = dfies_table
+        EXCEPTIONS
+          not_found      = 1
+          internal_error = 2
+          OTHERS         = 3.
+      IF sy-subrc = 0.
+        "dfies dictionary definition
+        READ TABLE dfies_table INTO fieldinfo-dfies INDEX 1.
+        IF sy-subrc > 0.
+          fieldinfo-dfies-fieldname = '%%%'.
+        ENDIF.
+        "get cute definition
+        READ TABLE zif_cute_source_info~cute_fields INTO fieldinfo-cute WITH TABLE KEY fieldname = fieldname.
+        IF sy-subrc > 0.
+          fieldinfo-cute-fieldname = '%%%'.
+        ENDIF.
+        "insert field information
+        INSERT fieldinfo INTO TABLE zif_cute_source_info~fieldinfos.
+
+      ENDIF.
+
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_cute_source_info~read.
+
+    DATA source_name TYPE typename.
+    zif_cute_source_info~class = 'TRANSP'.
+    zif_cute_source_info~name  = source.
+
+    SELECT SINGLE * FROM zcute_tech INTO zif_cute_source_info~cute_tech WHERE typename = source.
+    IF sy-subrc > 0.
+      RAISE EXCEPTION TYPE zcx_cute_not_defined.
+    ELSE.
+      SELECT * FROM zcute_field INTO TABLE zif_cute_source_info~cute_fields
+       WHERE typename = source.
+    ENDIF.
+
+    CALL FUNCTION 'DDIF_TABL_GET'
+      EXPORTING
+        name          = zif_cute_source_info~name
+        state         = 'A'
+        langu         = sy-langu
+      IMPORTING
+        dd02v_wa      = header
+      TABLES
+        dd03p_tab     = components
+      EXCEPTIONS
+        illegal_input = 1
+        OTHERS        = 2.
+    IF sy-subrc > 0.
+      RAISE EXCEPTION TYPE zcx_cute_get_type.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_cute_source_info_tabl.clas.xml
+++ b/src/zcl_cute_source_info_tabl.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_CUTE_SOURCE_INFO_TABL</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CUTE - Info Table</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_cute_source_info_view.clas.abap
+++ b/src/zcl_cute_source_info_view.clas.abap
@@ -1,0 +1,84 @@
+CLASS zcl_cute_source_info_view DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES zif_cute_source_info.
+
+    DATA header TYPE dd25v.
+    DATA technical TYPE dd09l.
+    DATA components TYPE STANDARD TABLE OF dd27p.
+    DATA selection_criteria TYPE STANDARD TABLE OF dd28v.
+    DATA joins TYPE STANDARD TABLE OF dd28j.
+    DATA base_tables TYPE STANDARD TABLE OF dd26v.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_CUTE_SOURCE_INFO_VIEW IMPLEMENTATION.
+
+
+  METHOD zif_cute_source_info~get_field_info.
+
+    READ TABLE zif_cute_source_info~fieldinfos WITH TABLE KEY fieldname = fieldname INTO fieldinfo.
+    IF sy-subrc > 0.
+      fieldinfo-fieldname = fieldname.
+
+      CALL FUNCTION 'DDIF_FIELDINFO_GET'
+        EXPORTING
+          tabname        = zif_cute_source_info~name
+          fieldname      = CONV fieldname( fieldname )
+          langu          = sy-langu
+          all_types      = 'X'
+          group_names    = ' '
+          do_not_write   = 'X'
+        IMPORTING
+          dfies_wa       = fieldinfo-dfies
+        EXCEPTIONS
+          not_found      = 1
+          internal_error = 2
+          OTHERS         = 3.
+      IF sy-subrc = 0.
+        INSERT fieldinfo INTO TABLE zif_cute_source_info~fieldinfos.
+      ENDIF.
+
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_cute_source_info~read.
+
+    zif_cute_source_info~class = 'VIEW'.
+    zif_cute_source_info~name  = source.
+    SELECT SINGLE * FROM zcute_tech INTO zif_cute_source_info~cute_tech WHERE typename = source.
+    IF sy-subrc > 0.
+      RAISE EXCEPTION TYPE zcx_cute_not_defined.
+    ELSE.
+      SELECT * FROM zcute_field INTO TABLE zif_cute_source_info~cute_fields
+       WHERE typename = source.
+    ENDIF.
+
+    CALL FUNCTION 'DDIF_VIEW_GET'
+      EXPORTING
+        name          = zif_cute_source_info~name
+        state         = 'A'
+        langu         = sy-langu
+      IMPORTING
+        dd25v_wa      = header
+        dd09l_wa      = technical
+      TABLES
+        dd26v_tab     = base_tables
+        dd27p_tab     = components
+        dd28j_tab     = joins
+        dd28v_tab     = selection_criteria
+      EXCEPTIONS
+        illegal_input = 1
+        OTHERS        = 2.
+    IF sy-subrc <> 0.
+      RAISE EXCEPTION TYPE zcx_cute_get_type.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_cute_source_info_view.clas.xml
+++ b/src/zcl_cute_source_info_view.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_CUTE_SOURCE_INFO_VIEW</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CUTE - Info View</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_cute_source_information.clas.abap
+++ b/src/zcl_cute_source_information.clas.abap
@@ -1,0 +1,55 @@
+CLASS zcl_cute_source_information DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+  PUBLIC SECTION.
+    CLASS-METHODS get_instance
+      IMPORTING
+        source          TYPE clike
+      RETURNING
+        VALUE(instance) TYPE REF TO zif_cute_source_info.
+    CLASS-METHODS get_source_type
+      IMPORTING
+        source          TYPE clike
+      RETURNING
+        VALUE(typekind) TYPE ddtypekind.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_CUTE_SOURCE_INFORMATION IMPLEMENTATION.
+
+
+  METHOD get_instance.
+    CASE get_source_type( source ).
+      WHEN 'TABL'.
+        instance = NEW zcl_cute_source_info_tabl( ).
+      WHEN 'VIEW'.
+        instance = NEW zcl_cute_source_info_view( ).
+    ENDCASE.
+
+    IF instance IS BOUND.
+      TRY.
+          instance->read( source ).
+        CATCH zcx_cute.
+      ENDTRY.
+    ENDIF.
+  ENDMETHOD.
+
+
+  METHOD get_source_type.
+    DATA source_name TYPE typename.
+    DATA gotstate TYPE ddgotstate.
+
+    source_name = source.
+
+    CALL FUNCTION 'DDIF_TYPEINFO_GET'
+      EXPORTING
+        typename = source_name
+      IMPORTING
+        typekind = typekind
+        gotstate = gotstate.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_cute_source_information.clas.xml
+++ b/src/zcl_cute_source_information.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_CUTE_SOURCE_INFORMATION</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CUTE - Source Information</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_cute_tab_helper.clas.abap
+++ b/src/zcl_cute_tab_helper.clas.abap
@@ -1,0 +1,150 @@
+
+CLASS zcl_cute_tab_helper DEFINITION PUBLIC FINAL CREATE PUBLIC.
+  PUBLIC SECTION.
+    CLASS-METHODS get_instance
+      IMPORTING
+        source_info     TYPE REF TO zif_cute_source_info
+      RETURNING
+        VALUE(instance) TYPE REF TO zcl_cute_tab_helper.
+    METHODS set_source
+      IMPORTING
+        source_info TYPE REF TO zif_cute_source_info.
+    METHODS get_components
+      RETURNING
+        VALUE(components) TYPE cl_abap_structdescr=>component_table.
+    METHODS set_components
+      IMPORTING
+        components TYPE cl_abap_structdescr=>component_table.
+    METHODS get_data_reference_edit
+      RETURNING
+        VALUE(dataref) TYPE REF TO data.
+    METHODS get_data_reference_origin
+      RETURNING
+        VALUE(dataref) TYPE REF TO data.
+    METHODS get_field_catalog
+      IMPORTING
+        grid        TYPE REF TO cl_gui_alv_grid
+      RETURNING
+        VALUE(fcat) TYPE lvc_t_fcat.
+  PRIVATE SECTION.
+    METHODS create.
+    DATA struc_origin_descr TYPE REF TO cl_abap_structdescr.
+    DATA table_origin_descr TYPE REF TO cl_abap_tabledescr.
+    DATA table_origin_data TYPE REF TO data.
+
+    DATA table_edit_data TYPE REF TO data.
+    DATA table_edit_descr TYPE REF TO cl_abap_tabledescr.
+    DATA struc_edit_descr TYPE REF TO cl_abap_structdescr.
+    DATA source_information TYPE REF TO zif_cute_source_info.
+    DATA components TYPE cl_abap_structdescr=>component_table.
+ENDCLASS.
+
+
+
+CLASS ZCL_CUTE_TAB_HELPER IMPLEMENTATION.
+
+
+  METHOD create.
+    struc_origin_descr = CAST cl_abap_structdescr( cl_abap_structdescr=>describe_by_name( source_information->name ) ).
+
+    "Needed to save data
+    table_origin_descr = cl_abap_tabledescr=>create(
+      p_line_type  = struc_origin_descr
+      p_table_kind = cl_abap_tabledescr=>tablekind_std
+      p_unique     = abap_false ).
+
+    CREATE DATA table_origin_data TYPE HANDLE table_origin_descr.
+
+    "Adapt editable structure
+    components = struc_origin_descr->get_components( ).
+
+    APPEND VALUE #( name = '_COLOR_' type = CAST cl_abap_datadescr( cl_abap_structdescr=>describe_by_name( 'LVC_T_SCOL' ) ) )
+    TO components.
+
+    struc_edit_descr = cl_abap_structdescr=>create( components ).
+
+    table_edit_descr = cl_abap_tabledescr=>create(
+      p_line_type  = struc_edit_descr
+      p_table_kind = cl_abap_tabledescr=>tablekind_std
+      p_unique     = abap_false ).
+
+    CREATE DATA table_edit_data TYPE HANDLE table_edit_descr.
+  ENDMETHOD.
+
+
+  METHOD get_components.
+  ENDMETHOD.
+
+
+  METHOD get_data_reference_edit.
+    dataref = table_edit_data.
+  ENDMETHOD.
+
+
+  METHOD get_data_reference_origin.
+    dataref = table_origin_data.
+  ENDMETHOD.
+
+
+  METHOD get_field_catalog.
+    DATA element_descr TYPE REF TO cl_abap_elemdescr.
+    DATA field_descr TYPE dfies.
+
+    LOOP AT components INTO DATA(component).
+      TRY.
+          element_descr ?= component-type.
+          field_descr = element_descr->get_ddic_field( ).
+          CHECK field_descr-datatype <> 'CLNT'.
+          APPEND INITIAL LINE TO fcat ASSIGNING FIELD-SYMBOL(<field>).
+          MOVE-CORRESPONDING field_descr TO <field>.
+          <field>-fieldname = component-name.
+          <field>-reptext   = field_descr-fieldname.
+          <field>-scrtext_s = field_descr-fieldname.
+          <field>-scrtext_m = field_descr-fieldname.
+          <field>-scrtext_l = field_descr-fieldname.
+          <field>-ref_table = source_information->name.
+
+          DATA(field_info) = source_information->get_field_info( component-name ).
+          IF field_info-cute-read_only = abap_false.
+            <field>-edit      = abap_true.
+          ENDIF.
+
+          CASE field_info-cute-fieldtype.
+            WHEN 'CB'.
+              <field>-checkbox = abap_true.
+            WHEN 'LK' OR 'LT' OR 'LB'.
+              <field>-drdn_hndl  = field_info-dfies-position.
+              <field>-drdn_alias = 'X'.
+              grid->set_drop_down_table(
+                  it_drop_down_alias = zcl_cute_listbox_helper=>get_listbox_for_fix_values(
+                    handle  = <field>-drdn_hndl
+                    type    = field_info-cute-fieldtype
+                    domname = field_info-dfies-domname ) ).
+            WHEN 'IC'.
+              <field>-icon = abap_true.
+
+          ENDCASE.
+
+        CATCH cx_sy_move_cast_error.
+          CONTINUE.
+      ENDTRY.
+
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD get_instance.
+    instance = NEW zcl_cute_tab_helper( ).
+    instance->set_source( source_info ).
+    instance->create( ).
+  ENDMETHOD.
+
+
+  METHOD set_components.
+  ENDMETHOD.
+
+
+  METHOD set_source.
+    source_information = source_info.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_cute_tab_helper.clas.xml
+++ b/src/zcl_cute_tab_helper.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_CUTE_TAB_HELPER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CUTE - Tab Helper</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcute_main.prog.abap
+++ b/src/zcute_main.prog.abap
@@ -6,455 +6,9 @@ PARAMETERS p_table TYPE typename DEFAULT 'ZCUTE_TEST'.
 
 INCLUDE <cl_alv_control>.
 
-CLASS lcx_cute DEFINITION INHERITING FROM cx_static_check. ENDCLASS.
-CLASS lcx_cute_unsupported_category DEFINITION INHERITING FROM lcx_cute. ENDCLASS.
-CLASS lcx_cute_not_defined DEFINITION INHERITING FROM lcx_cute. ENDCLASS.
-CLASS lcx_cute_get_type DEFINITION INHERITING FROM lcx_cute. ENDCLASS.
-
-INTERFACE lif_cute_source_info.
-  TYPES: BEGIN OF fieldinfo,
-           fieldname TYPE fieldname,
-           dfies     TYPE dfies,
-           catalog   TYPE lvc_s_fcat,
-           cute      TYPE zcute_field,
-           domvalues TYPE dd07vtab,
-         END OF fieldinfo.
-  METHODS read
-    IMPORTING
-              source TYPE clike
-    RAISING   lcx_cute.
-  METHODS get_field_info
-    IMPORTING
-      fieldname        TYPE clike
-    RETURNING
-      VALUE(fieldinfo) TYPE fieldinfo.
-  DATA name TYPE typename.
-  DATA class TYPE tabclass.
-  DATA fieldinfos TYPE SORTED TABLE OF fieldinfo WITH UNIQUE KEY fieldname.
-  DATA cute_tech TYPE zcute_tech.
-  DATA cute_fields TYPE SORTED TABLE OF zcute_field WITH UNIQUE KEY fieldname.
-ENDINTERFACE.
-
-CLASS lcl_cute_listbox_helper DEFINITION.
-  PUBLIC SECTION.
-    CLASS-METHODS get_listbox_for_fix_values
-      IMPORTING
-        domname              TYPE domname
-        handle               TYPE i
-        type                 TYPE zcute_field_display_type
-      RETURNING
-        VALUE(listbox_alias) TYPE lvc_t_dral.
-ENDCLASS.
-
-CLASS lcl_cute_listbox_helper IMPLEMENTATION.
-  METHOD get_listbox_for_fix_values.
-    DATA fix_values     TYPE STANDARD TABLE OF dd07v.
-
-    CALL FUNCTION 'DD_DOMVALUES_GET'
-      EXPORTING
-        domname        = domname
-        text           = 'X'
-        langu          = sy-langu
-      TABLES
-        dd07v_tab      = fix_values
-      EXCEPTIONS
-        wrong_textflag = 1
-        OTHERS         = 2.
-    IF sy-subrc = 0.
-      CASE type.
-        WHEN 'LK'.
-          listbox_alias = VALUE #( FOR value IN fix_values ( handle = handle int_value = value-domvalue_l value = value-domvalue_l ) ).
-        WHEN 'LT'.
-          listbox_alias = VALUE #( FOR value IN fix_values ( handle = handle int_value = value-domvalue_l value = value-ddtext ) ).
-        WHEN 'LB'.
-          listbox_alias = VALUE #( FOR value IN fix_values ( handle = handle int_value = value-domvalue_l value = |{ value-domvalue_l } { value-ddtext }| ) ).
-      ENDCASE.
-    ENDIF.
-
-  ENDMETHOD.
-ENDCLASS.
-
-
-
-CLASS lcl_cute_source_info_tabl DEFINITION.
-  PUBLIC SECTION.
-    INTERFACES lif_cute_source_info.
-
-    DATA header TYPE dd02v.
-    DATA technical TYPE dd09v.
-    DATA components TYPE STANDARD TABLE OF dd03p.
-
-ENDCLASS.
-
-CLASS lcl_cute_source_info_tabl IMPLEMENTATION.
-
-  METHOD lif_cute_source_info~read.
-
-    DATA source_name TYPE typename.
-    lif_cute_source_info~class = 'TRANSP'.
-    lif_cute_source_info~name  = source.
-
-    SELECT SINGLE * FROM zcute_tech INTO lif_cute_source_info~cute_tech WHERE typename = source.
-    IF sy-subrc > 0.
-      RAISE EXCEPTION TYPE lcx_cute_not_defined.
-    ELSE.
-      SELECT * FROM zcute_field INTO TABLE lif_cute_source_info~cute_fields
-       WHERE typename = source.
-    ENDIF.
-
-    CALL FUNCTION 'DDIF_TABL_GET'
-      EXPORTING
-        name          = lif_cute_source_info~name
-        state         = 'A'
-        langu         = sy-langu
-      IMPORTING
-        dd02v_wa      = header
-      TABLES
-        dd03p_tab     = components
-      EXCEPTIONS
-        illegal_input = 1
-        OTHERS        = 2.
-    IF sy-subrc > 0.
-      RAISE EXCEPTION TYPE lcx_cute_get_type.
-    ENDIF.
-
-  ENDMETHOD.
-
-  METHOD lif_cute_source_info~get_field_info.
-
-    DATA dfies_table TYPE STANDARD TABLE OF dfies.
-
-    READ TABLE lif_cute_source_info~fieldinfos WITH TABLE KEY fieldname = fieldname INTO fieldinfo.
-    IF sy-subrc > 0.
-      fieldinfo-fieldname = fieldname.
-
-      CALL FUNCTION 'DDIF_FIELDINFO_GET'
-        EXPORTING
-          tabname        = lif_cute_source_info~name
-          fieldname      = CONV fieldname( fieldname )
-          langu          = sy-langu
-          all_types      = 'X'
-          group_names    = ' '
-          do_not_write   = 'X'
-        TABLES
-          dfies_tab      = dfies_table
-        EXCEPTIONS
-          not_found      = 1
-          internal_error = 2
-          OTHERS         = 3.
-      IF sy-subrc = 0.
-        "dfies dictionary definition
-        READ TABLE dfies_table INTO fieldinfo-dfies INDEX 1.
-        IF sy-subrc > 0.
-          fieldinfo-dfies-fieldname = '%%%'.
-        ENDIF.
-        "get cute definition
-        READ TABLE lif_cute_source_info~cute_fields INTO fieldinfo-cute WITH TABLE KEY fieldname = fieldname.
-        IF sy-subrc > 0.
-          fieldinfo-cute-fieldname = '%%%'.
-        ENDIF.
-        "insert field information
-        INSERT fieldinfo INTO TABLE lif_cute_source_info~fieldinfos.
-
-      ENDIF.
-
-    ENDIF.
-
-  ENDMETHOD.
-
-ENDCLASS.
-CLASS lcl_cute_source_info_view DEFINITION.
-  PUBLIC SECTION.
-    INTERFACES lif_cute_source_info.
-
-    DATA header TYPE dd25v.
-    DATA technical TYPE dd09l.
-    DATA components TYPE STANDARD TABLE OF dd27p.
-    DATA selection_criteria TYPE STANDARD TABLE OF dd28v.
-    DATA joins TYPE STANDARD TABLE OF dd28j.
-    DATA base_tables TYPE STANDARD TABLE OF dd26v.
-
-ENDCLASS.
-
-CLASS lcl_cute_source_info_view IMPLEMENTATION.
-
-  METHOD lif_cute_source_info~read.
-
-    lif_cute_source_info~class = 'VIEW'.
-    lif_cute_source_info~name  = source.
-    SELECT SINGLE * FROM zcute_tech INTO lif_cute_source_info~cute_tech WHERE typename = source.
-    IF sy-subrc > 0.
-      RAISE EXCEPTION TYPE lcx_cute_not_defined.
-    ELSE.
-      SELECT * FROM zcute_field INTO TABLE lif_cute_source_info~cute_fields
-       WHERE typename = source.
-    ENDIF.
-
-    CALL FUNCTION 'DDIF_VIEW_GET'
-      EXPORTING
-        name          = lif_cute_source_info~name
-        state         = 'A'
-        langu         = sy-langu
-      IMPORTING
-        dd25v_wa      = header
-        dd09l_wa      = technical
-      TABLES
-        dd26v_tab     = base_tables
-        dd27p_tab     = components
-        dd28j_tab     = joins
-        dd28v_tab     = selection_criteria
-      EXCEPTIONS
-        illegal_input = 1
-        OTHERS        = 2.
-    IF sy-subrc <> 0.
-      RAISE EXCEPTION TYPE lcx_cute_get_type.
-    ENDIF.
-
-  ENDMETHOD.
-
-  METHOD lif_cute_source_info~get_field_info.
-
-    READ TABLE lif_cute_source_info~fieldinfos WITH TABLE KEY fieldname = fieldname INTO fieldinfo.
-    IF sy-subrc > 0.
-      fieldinfo-fieldname = fieldname.
-
-      CALL FUNCTION 'DDIF_FIELDINFO_GET'
-        EXPORTING
-          tabname        = lif_cute_source_info~name
-          fieldname      = CONV fieldname( fieldname )
-          langu          = sy-langu
-          all_types      = 'X'
-          group_names    = ' '
-          do_not_write   = 'X'
-        IMPORTING
-          dfies_wa       = fieldinfo-dfies
-        EXCEPTIONS
-          not_found      = 1
-          internal_error = 2
-          OTHERS         = 3.
-      IF sy-subrc = 0.
-        INSERT fieldinfo INTO TABLE lif_cute_source_info~fieldinfos.
-      ENDIF.
-
-    ENDIF.
-
-  ENDMETHOD.
-ENDCLASS.
-
-CLASS lcl_cute_source_information DEFINITION.
-  PUBLIC SECTION.
-    CLASS-METHODS get_instance
-      IMPORTING
-        source          TYPE clike
-      RETURNING
-        VALUE(instance) TYPE REF TO lif_cute_source_info.
-    CLASS-METHODS get_source_type
-      IMPORTING
-        source          TYPE clike
-      RETURNING
-        VALUE(typekind) TYPE ddtypekind.
-
-ENDCLASS.
-
-
-CLASS lcl_cute_source_information IMPLEMENTATION.
-  METHOD get_instance.
-    CASE get_source_type( source ).
-      WHEN 'TABL'.
-        instance = NEW lcl_cute_source_info_tabl( ).
-      WHEN 'VIEW'.
-        instance = NEW lcl_cute_source_info_view( ).
-    ENDCASE.
-
-    IF instance IS BOUND.
-      TRY.
-          instance->read( source ).
-        CATCH lcx_cute.
-      ENDTRY.
-    ENDIF.
-  ENDMETHOD.
-  METHOD get_source_type.
-    DATA source_name TYPE typename.
-    DATA gotstate TYPE ddgotstate.
-
-    source_name = source.
-
-    CALL FUNCTION 'DDIF_TYPEINFO_GET'
-      EXPORTING
-        typename = source_name
-      IMPORTING
-        typekind = typekind
-        gotstate = gotstate.
-
-  ENDMETHOD.
-ENDCLASS.
-
-
-CLASS lcl_cute_tab_helper DEFINITION.
-  PUBLIC SECTION.
-    CLASS-METHODS get_instance
-      IMPORTING
-        source_info     TYPE REF TO lif_cute_source_info
-      RETURNING
-        VALUE(instance) TYPE REF TO lcl_cute_tab_helper.
-    METHODS set_source
-      IMPORTING
-        source_info TYPE REF TO lif_cute_source_info.
-    METHODS get_components
-      RETURNING
-        VALUE(components) TYPE cl_abap_structdescr=>component_table.
-    METHODS set_components
-      IMPORTING
-        components TYPE cl_abap_structdescr=>component_table.
-    METHODS get_data_reference_edit
-      RETURNING
-        VALUE(dataref) TYPE REF TO data.
-    METHODS get_data_reference_origin
-      RETURNING
-        VALUE(dataref) TYPE REF TO data.
-    METHODS get_field_catalog
-      IMPORTING
-        grid        TYPE REF TO cl_gui_alv_grid
-      RETURNING
-        VALUE(fcat) TYPE lvc_t_fcat.
-  PRIVATE SECTION.
-    METHODS create.
-    DATA struc_origin_descr TYPE REF TO cl_abap_structdescr.
-    DATA table_origin_descr TYPE REF TO cl_abap_tabledescr.
-    DATA table_origin_data TYPE REF TO data.
-
-    DATA table_edit_data TYPE REF TO data.
-    DATA table_edit_descr TYPE REF TO cl_abap_tabledescr.
-    DATA struc_edit_descr TYPE REF TO cl_abap_structdescr.
-    DATA source_information TYPE REF TO lif_cute_source_info.
-    DATA components TYPE cl_abap_structdescr=>component_table.
-ENDCLASS.
-
-CLASS lcl_cute_tab_helper IMPLEMENTATION.
-  METHOD get_instance.
-    instance = NEW lcl_cute_tab_helper( ).
-    instance->set_source( source_info ).
-    instance->create( ).
-  ENDMETHOD.
-
-  METHOD create.
-    struc_origin_descr = CAST cl_abap_structdescr( cl_abap_structdescr=>describe_by_name( source_information->name ) ).
-
-    "Needed to save data
-    table_origin_descr = cl_abap_tabledescr=>create(
-      p_line_type  = struc_origin_descr
-      p_table_kind = cl_abap_tabledescr=>tablekind_std
-      p_unique     = abap_false ).
-
-    CREATE DATA table_origin_data TYPE HANDLE table_origin_descr.
-
-    "Adapt editable structure
-    components = struc_origin_descr->get_components( ).
-
-    APPEND VALUE #( name = '_COLOR_' type = CAST cl_abap_datadescr( cl_abap_structdescr=>describe_by_name( 'LVC_T_SCOL' ) ) )
-    TO components.
-
-    struc_edit_descr = cl_abap_structdescr=>create( components ).
-
-    table_edit_descr = cl_abap_tabledescr=>create(
-      p_line_type  = struc_edit_descr
-      p_table_kind = cl_abap_tabledescr=>tablekind_std
-      p_unique     = abap_false ).
-
-    CREATE DATA table_edit_data TYPE HANDLE table_edit_descr.
-  ENDMETHOD.
-
-  METHOD set_components.
-  ENDMETHOD.
-
-  METHOD get_components.
-  ENDMETHOD.
-
-  METHOD get_data_reference_edit.
-    dataref = table_edit_data.
-  ENDMETHOD.
-  METHOD get_data_reference_origin.
-    dataref = table_origin_data.
-  ENDMETHOD.
-
-  METHOD set_source.
-    source_information = source_info.
-  ENDMETHOD.
-
-  METHOD get_field_catalog.
-    DATA element_descr TYPE REF TO cl_abap_elemdescr.
-    DATA field_descr TYPE dfies.
-
-    LOOP AT components INTO DATA(component).
-      TRY.
-          element_descr ?= component-type.
-          field_descr = element_descr->get_ddic_field( ).
-          CHECK field_descr-datatype <> 'CLNT'.
-          APPEND INITIAL LINE TO fcat ASSIGNING FIELD-SYMBOL(<field>).
-          MOVE-CORRESPONDING field_descr TO <field>.
-          <field>-fieldname = component-name.
-          <field>-reptext   = field_descr-fieldname.
-          <field>-scrtext_s = field_descr-fieldname.
-          <field>-scrtext_m = field_descr-fieldname.
-          <field>-scrtext_l = field_descr-fieldname.
-          <field>-ref_table = source_information->name.
-
-          DATA(field_info) = source_information->get_field_info( component-name ).
-          IF field_info-cute-read_only = abap_false.
-            <field>-edit      = abap_true.
-          ENDIF.
-
-          CASE field_info-cute-fieldtype.
-            WHEN 'CB'.
-              <field>-checkbox = abap_true.
-            WHEN 'LK' OR 'LT' OR 'LB'.
-              <field>-drdn_hndl  = field_info-dfies-position.
-              <field>-drdn_alias = 'X'.
-              grid->set_drop_down_table(
-                  it_drop_down_alias = lcl_cute_listbox_helper=>get_listbox_for_fix_values(
-                    handle  = <field>-drdn_hndl
-                    type    = field_info-cute-fieldtype
-                    domname = field_info-dfies-domname ) ).
-            WHEN 'IC'.
-              <field>-icon = abap_true.
-
-          ENDCASE.
-
-*          <field>-style = ALV_STYLE_FONT_ITALIC.
-*          <field>-style = ALV_STYLE_radio_checked.
-
-        CATCH cx_sy_move_cast_error.
-          CONTINUE.
-      ENDTRY.
-
-    ENDLOOP.
-  ENDMETHOD.
-
-ENDCLASS.
-
-
-INTERFACE lif_cute.
-  METHODS edit
-    IMPORTING
-      container TYPE REF TO cl_gui_container.
-  METHODS save.
-  METHODS check.
-  METHODS read.
-  METHODS map_edit_to_origin.
-  METHODS map_origin_to_edit.
-  METHODS set_source
-    IMPORTING
-      source_info TYPE REF TO lif_cute_source_info.
-  DATA source_information TYPE REF TO lif_cute_source_info.
-  DATA table_helper TYPE REF TO lcl_cute_tab_helper.
-  DATA container TYPE REF TO cl_gui_container.
-ENDINTERFACE.
-
-
-
 CLASS lcl_cute_table DEFINITION.
   PUBLIC SECTION.
-    INTERFACES lif_cute.
+    INTERFACES zif_cute.
   PRIVATE SECTION.
     DATA grid TYPE REF TO cl_gui_alv_grid.
     DATA splitter TYPE REF TO cl_gui_easy_splitter_container.
@@ -482,38 +36,38 @@ CLASS lcl_cute_table DEFINITION.
 ENDCLASS.
 
 CLASS lcl_cute_table IMPLEMENTATION.
-  METHOD lif_cute~edit.
-    lif_cute~container = container.
-    lif_cute~table_helper = lcl_cute_tab_helper=>get_instance( lif_cute~source_information ).
-    lif_cute~read( ).
+  METHOD zif_cute~edit.
+    zif_cute~container = container.
+    zif_cute~table_helper = zcl_cute_tab_helper=>get_instance( zif_cute~source_information ).
+    zif_cute~read( ).
     edit_grid( ).
   ENDMETHOD.
-  METHOD lif_cute~set_source.
-    lif_cute~source_information = source_info.
+  METHOD zif_cute~set_source.
+    zif_cute~source_information = source_info.
   ENDMETHOD.
 
-  METHOD lif_cute~read.
+  METHOD zif_cute~read.
     FIELD-SYMBOLS <table> TYPE table.
-    DATA(tabref) = lif_cute~table_helper->get_data_reference_origin( ).
+    DATA(tabref) = zif_cute~table_helper->get_data_reference_origin( ).
     ASSIGN tabref->* TO <table>.
 
-    SELECT * FROM (lif_cute~source_information->name)
+    SELECT * FROM (zif_cute~source_information->name)
       INTO TABLE <table>.
 
-    lif_cute~map_origin_to_edit( ).
+    zif_cute~map_origin_to_edit( ).
 
   ENDMETHOD.
 
-  METHOD lif_cute~save.
+  METHOD zif_cute~save.
     FIELD-SYMBOLS <origin_data> TYPE table.
 
-    lif_cute~map_edit_to_origin( ).
+    zif_cute~map_edit_to_origin( ).
 
-    DATA(origin_data) = lif_cute~table_helper->get_data_reference_origin( ).
+    DATA(origin_data) = zif_cute~table_helper->get_data_reference_origin( ).
     ASSIGN origin_data->* TO <origin_data>.
 
 
-    MODIFY (lif_cute~source_information->name)
+    MODIFY (zif_cute~source_information->name)
       FROM TABLE <origin_data>.
     IF sy-subrc = 0.
       MESSAGE 'data has been saved.'(svs) TYPE 'S'.
@@ -523,19 +77,19 @@ CLASS lcl_cute_table IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD lif_cute~check.
+  METHOD zif_cute~check.
   ENDMETHOD.
 
   METHOD edit_grid.
 
     FIELD-SYMBOLS <edit_data> TYPE table.
 
-    DATA(edit_data) = lif_cute~table_helper->get_data_reference_edit( ).
+    DATA(edit_data) = zif_cute~table_helper->get_data_reference_edit( ).
     ASSIGN edit_data->* TO <edit_data>.
 
 
     splitter = NEW #(
-      parent        = lif_cute~container
+      parent        = zif_cute~container
       orientation   = cl_gui_easy_splitter_container=>orientation_vertical
       sash_position = 70 ).
 
@@ -552,7 +106,7 @@ CLASS lcl_cute_table IMPLEMENTATION.
     SET HANDLER handle_toolbar FOR grid.
 
     DATA layout TYPE lvc_s_layo.
-    DATA(fcat) = lif_cute~table_helper->get_field_catalog( grid ).
+    DATA(fcat) = zif_cute~table_helper->get_field_catalog( grid ).
 
     grid->set_table_for_first_display(
       EXPORTING
@@ -587,9 +141,9 @@ CLASS lcl_cute_table IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD lif_cute~map_edit_to_origin.
-    DATA(origin_data) = lif_cute~table_helper->get_data_reference_origin( ).
-    DATA(edit_data)   = lif_cute~table_helper->get_data_reference_edit( ).
+  METHOD zif_cute~map_edit_to_origin.
+    DATA(origin_data) = zif_cute~table_helper->get_data_reference_origin( ).
+    DATA(edit_data)   = zif_cute~table_helper->get_data_reference_edit( ).
 
     FIELD-SYMBOLS <origin_data> TYPE table.
     FIELD-SYMBOLS <edit_data> TYPE table.
@@ -602,10 +156,10 @@ CLASS lcl_cute_table IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD lif_cute~map_origin_to_edit.
+  METHOD zif_cute~map_origin_to_edit.
 
-    DATA(origin_data) = lif_cute~table_helper->get_data_reference_origin( ).
-    DATA(edit_data)   = lif_cute~table_helper->get_data_reference_edit( ).
+    DATA(origin_data) = zif_cute~table_helper->get_data_reference_origin( ).
+    DATA(edit_data)   = zif_cute~table_helper->get_data_reference_edit( ).
 
     FIELD-SYMBOLS <origin_data> TYPE table.
     FIELD-SYMBOLS <edit_data> TYPE table.
@@ -634,11 +188,11 @@ CLASS lcl_cute_table IMPLEMENTATION.
     AND   e_onf4_before IS INITIAL.
 
     LOOP AT er_data_changed->mt_good_cells INTO DATA(good_cell).
-      DATA(field_info) = lif_cute~source_information->get_field_info( good_cell-fieldname ).
+      DATA(field_info) = zif_cute~source_information->get_field_info( good_cell-fieldname ).
 
 *      CALL FUNCTION 'DDUT_INPUT_CHECK'
 *        EXPORTING
-*          tabname           = lif_cute~source_information->name
+*          tabname           = zif_cute~source_information->name
 *          fieldname         = conv FNAM_____4( good_cell-fieldname )
 *          value             = good_cell-value
 *          value_is_external = 'X'
@@ -697,7 +251,7 @@ CLASS lcl_cute_table IMPLEMENTATION.
   METHOD handle_user_command.
     CASE e_ucomm.
       WHEN 'SAVE'.
-        lif_cute~save( ).
+        zif_cute~save( ).
       WHEN OTHERS.
     ENDCASE.
   ENDMETHOD.
@@ -710,9 +264,9 @@ CLASS lcl_cute_main DEFINITION.
       IMPORTING
         source          TYPE typename
       RETURNING
-        VALUE(instance) TYPE REF TO lif_cute
+        VALUE(instance) TYPE REF TO zif_cute
       RAISING
-        lcx_cute.
+        zcx_cute.
   PROTECTED SECTION.
 
 ENDCLASS.
@@ -721,7 +275,7 @@ ENDCLASS.
 CLASS lcl_cute_main IMPLEMENTATION.
   METHOD get_instance.
 
-    DATA(source_info) = lcl_cute_source_information=>get_instance( source ).
+    DATA(source_info) = zcl_cute_source_information=>get_instance( source ).
 
     CASE source_info->class.
       WHEN 'TRANSP'.
@@ -729,7 +283,7 @@ CLASS lcl_cute_main IMPLEMENTATION.
         instance->set_source( source_info ).
       WHEN 'VIEW'.
       WHEN OTHERS.
-        RAISE EXCEPTION TYPE lcx_cute_unsupported_category.
+        RAISE EXCEPTION TYPE zcx_cute_unsupported_category.
     ENDCASE.
   ENDMETHOD.
 
@@ -744,6 +298,6 @@ AT SELECTION-SCREEN.
   TRY.
       DATA(cute) = lcl_cute_main=>get_instance( p_table ).
       cute->edit( NEW cl_gui_dialogbox_container( top = 10 left = 10 height = 600 width = 1500 ) ).
-    CATCH lcx_cute.
+    CATCH zcx_cute.
       MESSAGE 'error' TYPE 'I'.
   ENDTRY.

--- a/src/zcx_cute.clas.abap
+++ b/src/zcx_cute.clas.abap
@@ -1,0 +1,28 @@
+class ZCX_CUTE definition
+  public
+  inheriting from CX_STATIC_CHECK
+  create public .
+
+public section.
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like TEXTID optional
+      !PREVIOUS like PREVIOUS optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_CUTE IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+TEXTID = TEXTID
+PREVIOUS = PREVIOUS
+.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_cute.clas.xml
+++ b/src/zcx_cute.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_CUTE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Main Exception</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_CUTE</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcx_cute_get_type.clas.abap
+++ b/src/zcx_cute_get_type.clas.abap
@@ -1,0 +1,37 @@
+class ZCX_CUTE_GET_TYPE definition
+  public
+  inheriting from ZCX_CUTE
+  final
+  create public .
+
+public section.
+
+  interfaces IF_T100_DYN_MSG .
+  interfaces IF_T100_MESSAGE .
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like IF_T100_MESSAGE=>T100KEY optional
+      !PREVIOUS like PREVIOUS optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_CUTE_GET_TYPE IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+PREVIOUS = PREVIOUS
+.
+clear me->textid.
+if textid is initial.
+  IF_T100_MESSAGE~T100KEY = IF_T100_MESSAGE=>DEFAULT_TEXTID.
+else.
+  IF_T100_MESSAGE~T100KEY = TEXTID.
+endif.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_cute_get_type.clas.xml
+++ b/src/zcx_cute_get_type.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_CUTE_GET_TYPE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Get Type Exception</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_CUTE_GET_TYPE</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcx_cute_not_defined.clas.abap
+++ b/src/zcx_cute_not_defined.clas.abap
@@ -1,0 +1,37 @@
+class ZCX_CUTE_NOT_DEFINED definition
+  public
+  inheriting from ZCX_CUTE
+  final
+  create public .
+
+public section.
+
+  interfaces IF_T100_DYN_MSG .
+  interfaces IF_T100_MESSAGE .
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like IF_T100_MESSAGE=>T100KEY optional
+      !PREVIOUS like PREVIOUS optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_CUTE_NOT_DEFINED IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+PREVIOUS = PREVIOUS
+.
+clear me->textid.
+if textid is initial.
+  IF_T100_MESSAGE~T100KEY = IF_T100_MESSAGE=>DEFAULT_TEXTID.
+else.
+  IF_T100_MESSAGE~T100KEY = TEXTID.
+endif.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_cute_not_defined.clas.xml
+++ b/src/zcx_cute_not_defined.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_CUTE_NOT_DEFINED</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Not Defined Exception</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_CUTE_NOT_DEFINED</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcx_cute_unsupported_category.clas.abap
+++ b/src/zcx_cute_unsupported_category.clas.abap
@@ -1,0 +1,37 @@
+class ZCX_CUTE_UNSUPPORTED_CATEGORY definition
+  public
+  inheriting from ZCX_CUTE
+  final
+  create public .
+
+public section.
+
+  interfaces IF_T100_DYN_MSG .
+  interfaces IF_T100_MESSAGE .
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like IF_T100_MESSAGE=>T100KEY optional
+      !PREVIOUS like PREVIOUS optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_CUTE_UNSUPPORTED_CATEGORY IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+PREVIOUS = PREVIOUS
+.
+clear me->textid.
+if textid is initial.
+  IF_T100_MESSAGE~T100KEY = IF_T100_MESSAGE=>DEFAULT_TEXTID.
+else.
+  IF_T100_MESSAGE~T100KEY = TEXTID.
+endif.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_cute_unsupported_category.clas.xml
+++ b/src/zcx_cute_unsupported_category.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_CUTE_UNSUPPORTED_CATEGORY</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Unsupported Category Exception</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_CUTE_UNSUPPORTED_CATEGORY</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zif_cute.intf.abap
+++ b/src/zif_cute.intf.abap
@@ -1,0 +1,19 @@
+INTERFACE zif_cute
+  PUBLIC .
+
+  METHODS edit
+    IMPORTING
+      container TYPE REF TO cl_gui_container.
+  METHODS save.
+  METHODS check.
+  METHODS read.
+  METHODS map_edit_to_origin.
+  METHODS map_origin_to_edit.
+  METHODS set_source
+    IMPORTING
+      source_info TYPE REF TO zif_cute_source_info.
+  DATA source_information TYPE REF TO zif_cute_source_info.
+  DATA table_helper TYPE REF TO zcl_cute_tab_helper.
+  DATA container TYPE REF TO cl_gui_container.
+
+ENDINTERFACE.

--- a/src/zif_cute.intf.xml
+++ b/src/zif_cute.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_CUTE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CUTE - Main Interface</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zif_cute_source_info.intf.abap
+++ b/src/zif_cute_source_info.intf.abap
@@ -1,0 +1,23 @@
+INTERFACE zif_cute_source_info public.
+  TYPES: BEGIN OF fieldinfo,
+           fieldname TYPE fieldname,
+           dfies     TYPE dfies,
+           catalog   TYPE lvc_s_fcat,
+           cute      TYPE zcute_field,
+           domvalues TYPE dd07vtab,
+         END OF fieldinfo.
+  METHODS read
+    IMPORTING
+              source TYPE clike
+    RAISING   zcx_cute.
+  METHODS get_field_info
+    IMPORTING
+      fieldname        TYPE clike
+    RETURNING
+      VALUE(fieldinfo) TYPE fieldinfo.
+  DATA name TYPE typename.
+  DATA class TYPE tabclass.
+  DATA fieldinfos TYPE SORTED TABLE OF fieldinfo WITH UNIQUE KEY fieldname.
+  DATA cute_tech TYPE zcute_tech.
+  DATA cute_fields TYPE SORTED TABLE OF zcute_field WITH UNIQUE KEY fieldname.
+ENDINTERFACE.

--- a/src/zif_cute_source_info.intf.xml
+++ b/src/zif_cute_source_info.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_CUTE_SOURCE_INFO</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CUTE source info</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
because of issue #19 I extracted the local classes and made them globally. 

Only the classes lcl_cute_main and lcl_cute_table are left local. In my opinion they are directly related to this one report and it would be hard to use them otherwise. ( maybe the class lcl_cute_table can also be made globally - but the main class should stay local ) 

What do you think?
If it is okay, that the 2 classes stay local this PR can be merged ( from my side ^^ ) 